### PR TITLE
Merge in both 

### DIFF
--- a/client.py
+++ b/client.py
@@ -76,7 +76,7 @@ class Credentials(object):
             Configuration.get('google_app_email', 'google_app_p12_file',
                               'google_app_p12_secret', 'google_api_scopes',
                               not_null=True)
-        stream = open(p12_file, 'r')
+        stream = open(p12_file, 'rb')
         self._p12 = stream.read()
         stream.close()
         # check our credentials are those of a valid app

--- a/configuration.py
+++ b/configuration.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import yaml
+from ruamel.yaml import YAML
+yaml=YAML(typ='safe')
 
 
 from backend import *

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pycparser==2.14',
         'pyOpenSSL==0.15.1',
         'python-dateutil==2.4.2',
-        'PyYAML==3.11',
+        'ruamel.yaml==0.15.35',
         'rsa==3.2',
         'simplejson==3.8.0',
         'six==1.9.0',
@@ -40,10 +40,6 @@ setup(
         'uritemplate==0.6',
         'wheel==0.26.0'
     ],
-
-    dependency_links = [
-        "http://pyyaml.org/download/pyyaml/PyYAML-3.11.tar.gz"
-    ]
 )
 
 # for some reason, the developer of streaming_httplib2 didn't include the certificates


### PR DESCRIPTION
Change from pyyaml to ruamel.yaml for better windows compatibility.
Read p12 file in binary. Otherwise, the file is not read properly on Windows.