### PR TITLE
More intelligently file download + long file name support

### DIFF
--- a/model.py
+++ b/model.py
@@ -302,7 +302,12 @@ class Document(object):
     def title(self):
         # forbid os.sep in the name, and replace it with '_',
         # to prevent bugs when saving
-        return self.get_meta('title').replace(os.sep, '_')
+        title = self.get_meta('title').replace(os.sep, '_')
+        # Remove illegal characters from document title.
+        for illegalChar in ['/','~','#','&','*','\\','<','>','+','|','"','?',':']:
+          if illegalChar in title:
+            title=title.replace(illegalChar,'')
+        return title
 
     @property
     def is_owned(self):


### PR DESCRIPTION
More intelligently deal with files that have already been downloaded so we avoid re-downloading.
Enable long file name support on windows to allow for more than 255 characters.